### PR TITLE
kyotocabinet.opam: mark jbuilder as a build-time dependency

### DIFF
--- a/kyotocabinet.opam
+++ b/kyotocabinet.opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "build" "--only" "kyotocabinet" "--root" "." "-j" jobs "@install"]
 ]
 build-test: [ "jbuilder" "runtest" "-p" name ]
-depends: ["jbuilder"]
+depends: ["jbuilder" {build}]
 depexts: [
   [[ "ubuntu"] ["libkyotocabinet-dev"]]
   [[ "debian"] ["libkyotocabinet-dev"]]


### PR DESCRIPTION
It seems `jbuilder` is used only to build the package.  Mark that dependency as `{build}` in the opam file, so that `kyotocabinet` won't be rebuilt when a new version of `jbuilder` is installed.